### PR TITLE
Allow --scheme to be passed when reading from stdin

### DIFF
--- a/Tests/SwiftSyntaxHighlighterTests/CommandTests.swift
+++ b/Tests/SwiftSyntaxHighlighterTests/CommandTests.swift
@@ -1,13 +1,15 @@
 import XCTest
 import class Foundation.Bundle
 
-private let source = #"""
+fileprivate let source = #"""
 let greeting = "Hello, world!"
 """#
-private let expectedOutput = #"""
+
+fileprivate let expectedOutput = #"""
 <pre class="highlight"><code><span class="keyword">let</span> <span class="variable">greeting</span> = <span class="string literal">&quot;</span><span class="string literal">Hello, world!</span><span class="string literal">&quot;</span></code></pre>
 """#
-private let expectedPygmentsOutput = #"""
+
+fileprivate let expectedPygmentsOutput = #"""
 <pre class="highlight"><code><span class="kd">let</span><span class="w"> </span><span class="n">greeting</span><span class="w"> </span><span class="p">=</span><span class="w"> </span><span class="p">&quot;</span><span class="s2">Hello, world!</span><span class="p">&quot;</span></code></pre>
 """#
 

--- a/Tests/SwiftSyntaxHighlighterTests/CommandTests.swift
+++ b/Tests/SwiftSyntaxHighlighterTests/CommandTests.swift
@@ -1,60 +1,26 @@
 import XCTest
 import class Foundation.Bundle
 
+private let source = #"""
+let greeting = "Hello, world!"
+"""#
+private let expectedOutput = #"""
+<pre class="highlight"><code><span class="keyword">let</span> <span class="variable">greeting</span> = <span class="string literal">&quot;</span><span class="string literal">Hello, world!</span><span class="string literal">&quot;</span></code></pre>
+"""#
+private let expectedPygmentsOutput = #"""
+<pre class="highlight"><code><span class="kd">let</span><span class="w"> </span><span class="n">greeting</span><span class="w"> </span><span class="p">=</span><span class="w"> </span><span class="p">&quot;</span><span class="s2">Hello, world!</span><span class="p">&quot;</span></code></pre>
+"""#
+
 final class CommandTests: XCTestCase {
-    func testHighlightArguments() throws {
-        guard #available(macOS 10.13, *) else { return }
-
-        let source = #"""
-        let greeting = "Hello, world!"
-        """#
-
-        let expected = #"""
-        <pre class="highlight"><code><span class="kd">let</span><span class="w"> </span><span class="n">greeting</span><span class="w"> </span><span class="p">=</span><span class="w"> </span><span class="p">&quot;</span><span class="s2">Hello, world!</span><span class="p">&quot;</span></code></pre>
-        """#
-
-        let executable = productsDirectory.appendingPathComponent("swift-highlight")
-
+    @available(macOS 10.13, *)
+    private func runCommand(arguments: String..., standardInput: String = "") throws -> String? {
         let process = Process()
         process.executableURL = executable
-
-        process.arguments = [source, "--scheme", "pygments"]
-
-        var data = Data()
-        let outputPipe = Pipe()
-        defer { outputPipe.fileHandleForReading.closeFile() }
-        outputPipe.fileHandleForReading.readabilityHandler = { fileHandle in
-            data.append(fileHandle.availableData)
-        }
-        process.standardOutput = outputPipe
-
-        try process.run()
-        process.waitUntilExit()
-
-        let output = String(data: data, encoding: .utf8)
-
-        XCTAssertEqual(output, expected)
-    }
-
-    func testHighlightStandardInput() throws {
-        guard #available(macOS 10.13, *) else { return }
-
-        let source = #"""
-        let greeting = "Hello, world!"
-        """#
-
-        let expected = #"""
-        <pre class="highlight"><code><span class="keyword">let</span> <span class="variable">greeting</span> = <span class="string literal">&quot;</span><span class="string literal">Hello, world!</span><span class="string literal">&quot;</span></code></pre>
-        """#
-
-        let executable = productsDirectory.appendingPathComponent("swift-highlight")
-
-        let process = Process()
-        process.executableURL = executable
+        process.arguments = arguments
 
         let inputPipe = Pipe()
         inputPipe.fileHandleForWriting.writeabilityHandler = { fileHandle in
-            fileHandle.write(source.data(using: .utf8)!)
+            fileHandle.write(standardInput.data(using: .utf8)!)
             inputPipe.fileHandleForWriting.closeFile()
         }
         process.standardInput = inputPipe
@@ -67,12 +33,60 @@ final class CommandTests: XCTestCase {
         }
         process.standardOutput = outputPipe
 
+        process.standardError = FileHandle.nullDevice
+
         try process.run()
         process.waitUntilExit()
+        guard process.terminationStatus == EXIT_SUCCESS else { return nil }
 
-        let output = String(data: data, encoding: .utf8)
+        return String(data: data, encoding: .utf8)
+    }
 
-        XCTAssertEqual(output, expected)
+    func testHighlightArguments() throws {
+        guard #available(macOS 10.13, *) else { return }
+
+        do {
+            let output = try runCommand(arguments: source, "--scheme", "xcode")
+            XCTAssertEqual(output, expectedOutput)
+        }
+
+        do {
+            let output = try runCommand(arguments: source, "--scheme", "pygments")
+            XCTAssertEqual(output, expectedPygmentsOutput)
+        }
+
+        do {
+            let output = try runCommand(arguments: source)
+            XCTAssertEqual(output, expectedOutput)
+        }
+
+        do {
+            let output = try runCommand(arguments: source, "--scheme", "garbage")
+            XCTAssertNil(output)
+        }
+    }
+
+    func testHighlightStandardInput() throws {
+        guard #available(macOS 10.13, *) else { return }
+
+        do {
+            let output = try runCommand(standardInput: source)
+            XCTAssertEqual(output, expectedOutput)
+        }
+
+        do {
+            let output = try runCommand(arguments: "--scheme", "xcode", standardInput: source)
+            XCTAssertEqual(output, expectedOutput)
+        }
+
+        do {
+            let output = try runCommand(arguments: "--scheme", "pygments", standardInput: source)
+            XCTAssertEqual(output, expectedPygmentsOutput)
+        }
+    }
+
+    var executable: URL {
+        return productsDirectory.appendingPathComponent("swift-highlight")
     }
 
     /// Returns path to the built products directory.

--- a/Tests/SwiftSyntaxHighlighterTests/PygmentsTests.swift
+++ b/Tests/SwiftSyntaxHighlighterTests/PygmentsTests.swift
@@ -20,7 +20,6 @@ final class PygmentsTests: XCTestCase {
         </span><span class="p">}</span></code></pre>
         """#
 
-
         XCTAssertEqual(actual, expected)
     }
 }

--- a/Tests/SwiftSyntaxHighlighterTests/XcodeTests.swift
+++ b/Tests/SwiftSyntaxHighlighterTests/XcodeTests.swift
@@ -20,7 +20,6 @@ final class XcodeTests: XCTestCase {
         }</code></pre>
         """#
 
-
         XCTAssertEqual(actual, expected)
     }
 }


### PR DESCRIPTION
Previously, the decision of whether to read from stdin was based entirely on the number of arguments, but that doesn't allow for passing configuration options. Change the argument parser to use an optional positional argument for the input, and make the decision based on that instead.

I tried to match the existing coding style, but given the extent of the changes I made to CommandTest.swift I had to extrapolate a fair bit. Let me know if there's anything to do to bring it more in line.