### PR TITLE
Two small corrections to punctuation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The `swift-highlight` executable can be run from the command line
 to highlight either a path to a source file or source code:
 
 ```terminal
-$ swift highlight 'print("Hello, world!")"
+$ swift highlight 'print("Hello, world!")'
 <pre class="highlight"><code><span class="keyword">let</span> <span class="variable">greeting</span> = <span class="string literal">&quot;</span><span class="string literal">Hello, world!</span><span class="string literal">&quot;</span></code></pre>
 ```
 
@@ -30,7 +30,7 @@ Pass the `--scheme pygments` option
 to generate [Pygments](http://pygments.org)-compatible HTML:
 
 ```terminal
-$ swift highlight 'print("Hello, world!")" --scheme pygments
+$ swift highlight 'print("Hello, world!")' --scheme pygments
 <pre class="highlight"><code><span class="n">print</span><span class="p">(</span><span class="p">&quot;</span><span class="s2">Hello, world!</span><span class="p">&quot;</span><span class="p">)</span></code></pre>
 ```
 


### PR DESCRIPTION
Two small corrections that were needed to make the examples in README.md work correctly. 
Odd that the mismatched quotes got in there in the first place. 