### PR TITLE
Remove HTMLEntities dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,15 +13,16 @@ let package = Package(
                     targets: ["swift-highlight"])
     ],
     dependencies: [
-        .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .revision("0.50300.0")),
-        .package(name: "HTMLEntities", url: "https://github.com/IBM-Swift/swift-html-entities.git", from: "3.0.0"),
-        .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "0.0.4")),
+        .package(name: "SwiftSyntax",
+                 url: "https://github.com/apple/swift-syntax.git",
+                 .revision("0.50300.0")),
+        .package(name: "swift-argument-parser",
+                 url: "https://github.com/apple/swift-argument-parser.git",
+                 .upToNextMinor(from: "0.0.4")),
     ],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(name: "Highlighter",
-                dependencies: ["SwiftSyntax", "HTMLEntities"]),
+                dependencies: ["SwiftSyntax"]),
         .target(name: "Pygments",
                 dependencies: ["Highlighter"],
                 path: "Sources/TokenizationSchemes/Pygments"),

--- a/Sources/Highlighter/Token.swift
+++ b/Sources/Highlighter/Token.swift
@@ -1,5 +1,5 @@
 import SwiftSyntax
-import HTMLEntities
+import Foundation
 
 public struct Token {
     public var text: String
@@ -13,12 +13,38 @@ public struct Token {
 
 extension Token {
     public var html: String {
-        let escapedText = text.htmlEscape(useNamedReferences: true)
-
         if let className = className {
-            return #"<span class="\#(className)">\#(escapedText)</span>"#
+            return #"<span class="\#(className)">\#(text.escaped)</span>"#
         } else {
-            return escapedText
+            return text.escaped
+        }
+    }
+}
+
+fileprivate extension StringProtocol {
+    var escaped: String {
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+        return (CFXMLCreateStringByEscapingEntities(nil, String(self) as NSString, nil)! as NSString) as String
+        #else
+        return [
+            ("&", "&amp;"),
+            ("<", "&lt;"),
+            (">", "&gt;"),
+            ("'", "&apos;"),
+            ("\"", "&quot;"),
+        ].reduce(String(self)) { (string, element) in
+            string.replacingOccurrences(of: element.0, with: element.1)
+        }
+        #endif
+    }
+
+    func escapingOccurrences<Target>(of target: Target, options: String.CompareOptions = [], range searchRange: Range<String.Index>? = nil) -> String where Target : StringProtocol {
+        return replacingOccurrences(of: target, with: target.escaped, options: options, range: searchRange)
+    }
+
+    func escapingOccurrences<Target>(of targets: [Target], options: String.CompareOptions = []) -> String where Target : StringProtocol {
+        return targets.reduce(into: String(self)) { (result, target) in
+            result = result.escapingOccurrences(of: target, options: options)
         }
     }
 }

--- a/Tests/SwiftSyntaxHighlighterTests/PygmentsTests.swift
+++ b/Tests/SwiftSyntaxHighlighterTests/PygmentsTests.swift
@@ -16,7 +16,7 @@ final class PygmentsTests: XCTestCase {
         let expected = #"""
         <pre class="highlight"><code><span class="c1">/// Returns a personalized greeting.</span><span class="w">
         </span><span class="kd">func</span><span class="w"> </span><span class="n">greet</span><span class="p">(</span><span class="n">name</span><span class="p">:</span><span class="w"> </span><span class="nc">String</span><span class="p">)</span><span class="w"> </span><span class="p">-&gt;</span><span class="w"> </span><span class="n">String</span><span class="w"> </span><span class="p">{</span><span class="w">
-        </span><span class="w">    </span><span class="k">return</span><span class="w"> </span><span class="p">&quot;</span><span class="s2">Hello, </span><span class="p">\</span><span class="p">(</span><span class="n">name</span><span class="si">)</span><span class="s2">!</span><span class="p">&quot;</span><span class="w"> </span><span class="c1">// &#x1F44B;</span><span class="w">
+        </span><span class="w">    </span><span class="k">return</span><span class="w"> </span><span class="p">&quot;</span><span class="s2">Hello, </span><span class="p">\</span><span class="p">(</span><span class="n">name</span><span class="si">)</span><span class="s2">!</span><span class="p">&quot;</span><span class="w"> </span><span class="c1">// 👋</span><span class="w">
         </span><span class="p">}</span></code></pre>
         """#
 

--- a/Tests/SwiftSyntaxHighlighterTests/XcodeTests.swift
+++ b/Tests/SwiftSyntaxHighlighterTests/XcodeTests.swift
@@ -16,7 +16,7 @@ final class XcodeTests: XCTestCase {
         let expected = #"""
         <pre class="highlight"><code><span class="documentation">/// Returns a personalized greeting.</span>
         <span class="keyword">func</span> <span class="function">greet</span>(<span class="variable">name</span>: <span class="type">String</span>) -&gt; <span class="type">String</span> {
-            <span class="keyword">return</span> <span class="string literal">&quot;</span><span class="string literal">Hello, </span>\<span class="string literal">(</span><span class="variable">name</span><span class="string literal">)</span><span class="string literal">!</span><span class="string literal">&quot;</span> <span class="comment">// &#x1F44B;</span>
+            <span class="keyword">return</span> <span class="string literal">&quot;</span><span class="string literal">Hello, </span>\<span class="string literal">(</span><span class="variable">name</span><span class="string literal">)</span><span class="string literal">!</span><span class="string literal">&quot;</span> <span class="comment">// 👋</span>
         }</code></pre>
         """#
 


### PR DESCRIPTION
While working on [swift-doc](https://github.com/swiftdocorg/swift-doc), I noticed that the a significant chunk of the build time was stuck on this step:

```
[36/39] Compiling HTMLEntities Constants.swift
```

Searching around, I found [this issue](https://github.com/Kitura/swift-html-entities/issues/50), which described the slow compile time of the large dictionary literal ([SR-10209](https://bugs.swift.org/browse/SR-10209)).

Our use of `HTMLEntities` here is overkill — we need to escape only a handful of characters, and certainly don't need them to have named entities. This PR removes the dependency in favor of [a function I borrowed from @NSHipster/HypertextLiteral](https://github.com/NSHipster/HypertextLiteral/blob/e090e30f9a03d74c1189edd22def818833fe67a1/Sources/HypertextLiteral/HTML.swift#L372).  