### PR TITLE
build: bump swift-argument-parser to 0.3.2

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
         "state": {
           "branch": null,
-          "revision": "92646c0cdbaca076c8d3d0207891785b3379cbff",
-          "version": "0.3.1"
+          "revision": "9564d61b08a5335ae0a36f789a7d71493eacadfc",
+          "version": "0.3.2"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
                  .revision("0.50300.0")),
         .package(name: "swift-argument-parser",
                  url: "https://github.com/apple/swift-argument-parser.git",
-                 .upToNextMinor(from: "0.3.1"))
+                 .upToNextMinor(from: "0.3.2"))
     ],
     targets: [
         .target(name: "Highlighter",


### PR DESCRIPTION
In order to build on Windows, we need swift-argument-parser 0.3.2.